### PR TITLE
Backport commit 48b3603283c689e0e0f6c99c531841606e32f7eb from 3.7.1:

### DIFF
--- a/core/app/models/spree/payment_method/store_credit.rb
+++ b/core/app/models/spree/payment_method/store_credit.rb
@@ -1,5 +1,5 @@
 module Spree
-  class PaymentMethod::StoreCredit < PaymentMethod
+  class PaymentMethod::StoreCredit < ::Spree::PaymentMethod
     def payment_source_class
       ::Spree::StoreCredit
     end


### PR DESCRIPTION
 - Use class with namespace for payment methods to avoid Rails 5.2 caching problems #9263

> This fixes a random problem in development where the batch processing randomly fails